### PR TITLE
Add missing environments/config to code.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,4 @@ services:
     environment:
       - HONEYCOMB_API_KEY
       - HONEYCOMB_API_HOST
+      - HONEYCOMB_DATASET

--- a/refinery/config.toml
+++ b/refinery/config.toml
@@ -1,4 +1,4 @@
-ListenAddr = "0.0.0.0:8080"
+GRPCListenAddr = "0.0.0.0:8080"
 PeerListenAddr = "0.0.0.0:8081"
 HoneycombAPI = "https://api.honeycomb.io"
 LoggingLevel = "debug"

--- a/server.py
+++ b/server.py
@@ -4,7 +4,6 @@ import sys
 import requests
 from flask import Flask, request
 # Required for sending telemetry to Honeycomb
-from grpc import ssl_channel_credentials
 # Required instrumentation packages
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import \
@@ -19,12 +18,12 @@ from opentelemetry.sdk.trace.export import (BatchSpanProcessor,
 
 # Configure exporter to send to Honeycomb
 otlp_exporter = OTLPSpanExporter(
-    endpoint="api.honeycomb.io:443",
-    credentials=ssl_channel_credentials(),
+    endpoint=os.environ["HONEYCOMB_API_HOST"],
+    insecure=True,
     headers=(
         ("x-honeycomb-team", os.environ['HONEYCOMB_API_KEY']),
         ("x-honeycomb-dataset", os.environ['HONEYCOMB_DATASET'])
-    )
+    ),
 )
 
 
@@ -80,4 +79,4 @@ def fib():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=True, host="0.0.0.0")


### PR DESCRIPTION
Fixes #1 

A couple of important facts: 

1. You have to use `refinery:8080` and not `http://refinery:8080` as the communication between the app and the refinery instance happens over gRPC and not http. This will have to be reflected in the blog post also. 
2. You have to bind your flask code to `0.0.0.0`. Without this the server will not listen to any requests coming from other hosts. 
3. You have to pass `insecure=True` as the [honeycomb refinery documentation ](https://docs.honeycomb.io/manage-data-volume/refinery/configuration/) mentions that gRPC communication expects incoming traffic to be unencrypted. 

Let us know if you have any questions about this PR. Happy to help. cc: @thundering-herd 